### PR TITLE
Escape tx

### DIFF
--- a/chompchainwallet/contract.py
+++ b/chompchainwallet/contract.py
@@ -1,2 +1,14 @@
+import os
 from couchsurf import Connection
+from address import *
 
+CONN = Connection("contracts")
+data = CONN.request.query(
+    _id = {"op": "EQUALS", "arg": ADDRESS}
+)
+
+def owner(self, addr: str = ""):
+    pass
+
+def payable(self):
+    pass

--- a/chompchainwallet/transaction.py
+++ b/chompchainwallet/transaction.py
@@ -1,5 +1,7 @@
+import os
 import json
 import hashlib
+import requests
 from datetime import datetime
 from .interface import Wallet
 
@@ -11,6 +13,10 @@ class Transaction:
         wallet = Wallet()
 
         self.data = kwargs
+
+        for field in self.data:
+            self.data[field] = self.data[field].encode().decode()
+
         setattr(self, "to_addr", to_addr)
 
         if not from_addr:
@@ -31,3 +37,20 @@ class Transaction:
 
     def __str__(self):
         return json.dumps(self.__dict__, separators = (',', ':'))
+
+class CmdTransaction():
+
+    def __init__(self, command: str = ""):
+        transact = Transaction(
+            to_addr = "0x0",
+            cmd = command
+        )
+        transmit(transact)
+
+def transmit(txn: Transaction = Transaction()):
+    response = requests.post(
+        "http://cdr.theterm.world:7500/transactions/new",
+        data = json.dumps(txn.__dict__)
+    )
+    # TODO: Create a cache to save transactions in case
+    # we lose all connectivity with any node?


### PR DESCRIPTION
Escapes double-quoted strings on the command line, per the need to `sed` the double quotes to `\x22` bytes.