### PR TITLE
Updating with port-less server address

### DIFF
--- a/chompchainwallet/transaction.py
+++ b/chompchainwallet/transaction.py
@@ -49,7 +49,7 @@ class CmdTransaction():
 
 def transmit(txn: Transaction = Transaction()):
     response = requests.post(
-        "http://chain.chompe.rs:1815/transactions/new",
+        "https://chain.chompe.rs/transactions/new",
         data = json.dumps(txn.__dict__)
     )
     # TODO: Create a cache to save transactions in case


### PR DESCRIPTION
`main` still had a port-addressed endpoint in the `CmdTransaction` object. This is no good, as `chain.chompe.rs` answers on all HTTPS requests now.