### PR TITLE
Adopting new hex casting from pymerkle 5

### DIFF
--- a/chompchainwallet/address.py
+++ b/chompchainwallet/address.py
@@ -5,7 +5,7 @@ class Address:
     def __init__(self, public_key: MerkleTree, network: str = "100x"):
         """ Constructor """
         self.prefix = network
-        self.value = str(public_key.root.value)
+        self.value = public_key.root.value.hex()
 
     def __repr__(self) -> str:
         """ Representation """


### PR DESCRIPTION
Updates root value calculation to use `pymerkle`-implemented `hex` method on root hash value.